### PR TITLE
Memory leak fix

### DIFF
--- a/lib/pixelr.cc
+++ b/lib/pixelr.cc
@@ -65,6 +65,8 @@ Handle<Value> CreateObject(const Arguments& args) {
   obj->Set(String::NewSymbol("width"), Number::New(width));
   obj->Set(String::NewSymbol("height"), Number::New(height));
 
+  free(raw_image);
+
   return obj;
 }
 


### PR DESCRIPTION
raw_image wasn't getting freed, so every call to pixelr.read() was allocating more memory.  Adding free after where the buffer is copied to node resolves it.
